### PR TITLE
Add missing variable initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ install(TARGETS CommonAPI
         RUNTIME DESTINATION ${INSTALL_BIN_DIR}
         ARCHIVE DESTINATION ${INSTALL_LIB_DIR}
         PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDE_DIR}/CommonAPI"
+        INCLUDES DESTINATION ${INSTALL_INCLUDE_DIR}
 )
 
 ##############################################################################

--- a/include/CommonAPI/Deployable.hpp
+++ b/include/CommonAPI/Deployable.hpp
@@ -19,7 +19,8 @@ template<typename Type_, typename TypeDepl_>
 struct Deployable : DeployableBase
 {
     Deployable(const TypeDepl_ *_depl = nullptr)
-        : depl_(const_cast<TypeDepl_ *>(_depl)) {
+        : value_(),
+          depl_(const_cast<TypeDepl_ *>(_depl)) {
     }
 
     Deployable(const Type_ &_value, const TypeDepl_ *_depl)


### PR DESCRIPTION
Fixes following Undefined Behavior Sanitizer warning:
Deployable.hpp:31:16: runtime error: load of value 160, which is not a valid value for type 'bool'