### PR TITLE
some compiler or platform listener will hold invalid pointer

### DIFF
--- a/include/CommonAPI/Event.hpp
+++ b/include/CommonAPI/Event.hpp
@@ -111,8 +111,7 @@ typename Event<Arguments_...>::Subscription Event<Arguments_...>::subscribe(List
         std::lock_guard<std::recursive_mutex> itsLock(mutex_);
         subscription = nextSubscription_++;
         isFirstListener = (0 == pendingSubscriptions_.size()) && (pendingUnsubscriptions_.size() == subscriptions_.size());
-        listener = std::move(listener);
-        listeners = std::make_tuple(listener, std::move(errorListener));
+        listeners = std::make_tuple(std::move(listener), std::move(errorListener));
         pendingSubscriptions_[subscription] = std::move(listeners);
     }
 


### PR DESCRIPTION
My AOSP device occured the problem. It's weard, maybe it's caused by the compiler or the complier's opt operation.