### PR TITLE
Fix bad_function_call exception

### DIFF
--- a/include/CommonAPI/Event.hpp
+++ b/include/CommonAPI/Event.hpp
@@ -111,7 +111,6 @@ typename Event<Arguments_...>::Subscription Event<Arguments_...>::subscribe(List
         std::lock_guard<std::recursive_mutex> itsLock(mutex_);
         subscription = nextSubscription_++;
         isFirstListener = (0 == pendingSubscriptions_.size()) && (pendingUnsubscriptions_.size() == subscriptions_.size());
-        listener = std::move(listener);
         listeners = std::make_tuple(listener, std::move(errorListener));
         pendingSubscriptions_[subscription] = std::move(listeners);
     }


### PR DESCRIPTION
Issue occurs during notifyListeners() on LLVM compiler, e.g. on AOSP.
But GCC compiler ignors such meaningless line:
    listener = std::move(listener);
and threfore issue on GCC compiler is not reproducible.

Signed-off-by: Nikolay Khilyuk <nkh@ua.fm>