### PR TITLE
Logger: remove unused COMMONAPI_EXPORT

### DIFF
--- a/include/CommonAPI/Logger.hpp
+++ b/include/CommonAPI/Logger.hpp
@@ -28,7 +28,7 @@ namespace CommonAPI {
 
 class Logger {
 public:
-    enum class Level : std::uint8_t COMMONAPI_EXPORT {
+    enum class Level : std::uint8_t {
         CAPI_LOG_NONE = 0,
         CAPI_LOG_FATAL = 1,
         CAPI_LOG_ERROR = 2,


### PR DESCRIPTION
The structure is declared in the header and the export is unused as seen
with clang and `-Wignored-attributes`:

```
CommonAPI-3.2/CommonAPI/Logger.hpp:31:37: warning: 'visibility' attribute ignored when parsing type [-Wignored-attributes]
    enum class Level : std::uint8_t COMMONAPI_EXPORT {
                                    ^~~~~~~~~~~~~~~~
CommonAPI-3.2/CommonAPI/Export.hpp:19:46: note: expanded from macro 'COMMONAPI_EXPORT'
    #define COMMONAPI_EXPORT __attribute__ ((visibility ("default")))
                                             ^~~~~~~~~~~~~~~~~~~~~~
```

Closes: #25